### PR TITLE
Fix/prof-search-failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # VandyScheduler
+
 Vandy Scheduler is a Chrome Extension that allows you to easily choose classes that do not have conflicting times, automatically putting them into your cart. It creates all possible schedules based on the classes in your cart, and allows you to choose the schedule that best suits you. It does this by adding all available times of a certain class to the class cart when the "Add to Schedule" button is clicked. You can also choose times that you wish to have no class and choose classes in your cart that you don't want to be included in a schedule by clicking the "Preferences" button. Then, it allows you to choose the schedule that works best by clicking the "Make Schedule" button. These classes appear in the class cart. When time to enroll, you can click the "One Click Enroll" button to enroll in all classes in your cart with one click.
 
 Vandy Scheduler now shows professor ratings from Rate My Professor next their names!
+
 ## Chrome Web Store
+
 This extension can be downloaded at the Chrome Web Store [here](https://chrome.google.com/webstore/detail/vandy-scheduler/ofkamcklfkpakjddlappmemldnnapina?brand=CHBD&gclid=EAIaIQobChMI46ehtYrS1wIVirbACh19XA8iEAAYASABEgLat_D_BwE&gclsrc=aw.ds&dclid=CP6toraK0tcCFcVnAQodcRQNGA).
+
 ## How to use
+
 Just download from the Chrome Web Store and go to [Course Registration](https://acad.app.vanderbilt.edu/more/SearchClasses.action#) from your YES page, log in, and start using!
+
 ## Changelog
+
+- 2.0.6 - Fix for RMP
 - 2.0.5 - Another update to match RateMyProfessors site update. Also add the functionality of turning the professor name into a link that leads directly to their RateMyProfessors page.
 - 2.0.4 - Another update to match RateMyProfessors site update. Thanks to @DavidHuang2002
 - 2.0.3 - Another update to match RateMyProfessors site update.

--- a/background/background.js
+++ b/background/background.js
@@ -86,7 +86,9 @@ function extractProfId(pageText){
 		if(result.length == 0){
 			throw "error extracting the legacyId from the window\.__RELAY_STORE__ when trying to find profId. Possibly no professor is found"
 		} else if(result.length > 1){
-			throw "error extracting the legacyId from the window\.__RELAY_STORE__ when trying to find profId. Multiple matches found"
+			// throw "error extracting the legacyId from the window\.__RELAY_STORE__ when trying to find profId. Multiple matches found"
+			console.warn("Multiple matches found when trying to find profId. Returning the first match")
+			return result[0];
 		} else {
 			return result[0];
 		}

--- a/manifest.json
+++ b/manifest.json
@@ -1,27 +1,39 @@
 {
-   "manifest_version": 2,
-   "name": "Vandy Scheduler",
-   "version": "2.0.5",
-   "description": "This extension organizes your potential classes and Vanderbilt YES class cart into a schedule for the upcoming semester.",
-   "icons": {
-      "16": "png/schedule-icon16.png",
-      "32": "png/schedule-icon32.png",
-      "48": "png/schedule-icon48.png",
-      "64": "png/schedule-icon64.png",
-      "128": "png/schedule-icon128.png"
-   },
-   "content_scripts": [{
+  "manifest_version": 2,
+  "name": "Vandy Scheduler",
+  "version": "2.0.6",
+  "description": "This extension organizes your potential classes and Vanderbilt YES class cart into a schedule for the upcoming semester.",
+  "icons": {
+    "16": "png/schedule-icon16.png",
+    "32": "png/schedule-icon32.png",
+    "48": "png/schedule-icon48.png",
+    "64": "png/schedule-icon64.png",
+    "128": "png/schedule-icon128.png"
+  },
+  "content_scripts": [
+    {
       "matches": ["*://*.vanderbilt.edu/more/SearchClasses*"],
-      "js": ["src/jquery-3.2.1.min.js", "src/content.js", "src/class.js", "src/schedule.js", "src/ratemyprof.js", "src/subs.js", "src/restricted.js"],
+      "js": [
+        "src/jquery-3.2.1.min.js",
+        "src/content.js",
+        "src/class.js",
+        "src/schedule.js",
+        "src/ratemyprof.js",
+        "src/subs.js",
+        "src/restricted.js"
+      ],
       "css": ["css/myButton.css", "css/modal.css"],
       "all_frames": true
-   }],
-   "background": {
-      "scripts": ["background/background.js"],
-      "persistent": false
-   },
-   "permissions": [
-      "*://*.vanderbilt.edu/more/SearchClasses*", "storage", "https://www.ratemyprofessors.com/**"
-   ],
-   "web_accessible_resources": ["png/comment-pic2.png", "png/comment-pic3.png"]
+    }
+  ],
+  "background": {
+    "scripts": ["background/background.js"],
+    "persistent": false
+  },
+  "permissions": [
+    "*://*.vanderbilt.edu/more/SearchClasses*",
+    "storage",
+    "https://www.ratemyprofessors.com/**"
+  ],
+  "web_accessible_resources": ["png/comment-pic2.png", "png/comment-pic3.png"]
 }

--- a/src/ratemyprof.js
+++ b/src/ratemyprof.js
@@ -135,6 +135,8 @@ function convertName(original) {
 	if (temp[0].trim() in subs) {
 		temp[0] = subs[temp[0].trim()];
 	}
+	// strip away of "," since it is messing up some of the search
+	temp[0] = temp[0].replace(/,/g, '');
 	return encodeURIComponent(temp[0]);
 }
 


### PR DESCRIPTION
The search for some of the professors was failing probably because of some changes on the part of rate my professor's website -- a search with name "Aaa, Bbb" used to return precisely one prof. However, now it doesn't either return result or return multiple results. By removing the comma in search and only taking first result when there are multiple, we can resolve this problem for most professors.

Before the fix:
![Screenshot 2024-06-10 at 10 38 44 AM](https://github.com/quinton22/VandyScheduler/assets/55070299/4f90d4af-5944-4ef5-9b75-b1f6e3707e47)

After the fix:
![Screenshot 2024-06-10 at 10 38 00 AM](https://github.com/quinton22/VandyScheduler/assets/55070299/8316fb0a-ea91-424f-bebe-0ba78cdf9971)
